### PR TITLE
MES-1800: Log average journal size and save duration in journal poller

### DIFF
--- a/src/functions/pollJournals/framework/repo/dynamodb/journal-repository.ts
+++ b/src/functions/pollJournals/framework/repo/dynamodb/journal-repository.ts
@@ -28,6 +28,20 @@ export const saveJournals = async (journals: JournalWrapper[]): Promise<void> =>
   const maxBatchWriteRequests = 25;
   const journalWriteBatches = chunk(journals, maxBatchWriteRequests);
 
+  const averageJournalSize = journals
+    .reduce(
+      (progress, journal) => {
+        const newItemCount = progress.count + 1;
+        const differential = (JSON.stringify(journal).length - progress.average) / newItemCount;
+        return {
+          count: newItemCount,
+          average: progress.average + differential,
+        };
+      },
+      { count: 0, average: 0 },
+    ).average;
+  console.log(`AVERAGE JOURNAL SIZE BEING SAVED: ${averageJournalSize} BYTES`);
+
   const writeRequests = journalWriteBatches.map((batch) => {
     const params = {
       RequestItems: {


### PR DESCRIPTION
# Description and relevant Jira numbers
As per the request from @rstepnowski, logging two additional metrics relating to saving journals to DynamoDB:

1. The average size of the journals being saved.
2. The average duration of the DynamoDB batchWrite requests.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA