### PR TITLE
MES-1746: Compress journal payloads sent to DynamoDB

### DIFF
--- a/src/functions/pollJournals/application/__mocks__/test-journal-compression.ts
+++ b/src/functions/pollJournals/application/__mocks__/test-journal-compression.ts
@@ -1,0 +1,60 @@
+import { VehicleGearbox, Initiator } from '../../../../common/domain/Schema';
+
+export default {
+  journal: {
+    testSlots: [
+      {
+        booking: {
+          application: {
+            applicationId: 1234567,
+            bookingSequence: 3,
+            checkDigits: 1,
+            entitlementCheck: false,
+            extendedTest: false,
+            progressiveAccess: false,
+            specialNeeds: 'Candidate has dyslexia',
+            testCategory: 'A1',
+            vehicleGearbox: 'Automatic' as VehicleGearbox,
+            welshTest: false,
+          },
+          candidate: {
+            candidateAddress: {
+              addressLine1: '1 Station Street',
+              addressLine2: 'Someplace',
+              addressLine3: 'Sometown',
+              postcode: 'AB12 3CD',
+            },
+            candidateId: 101,
+            candidateName: {
+              firstName: 'Florence',
+              lastName: 'Pearson',
+              title: 'Miss',
+            },
+            driverNumber: 'PEARS015220A99HC',
+            mobileTelephone: '07654 123456',
+            primaryTelephone: '01234 567890',
+            secondaryTelephone: '04321 098765',
+          },
+          previousCancellation: [
+            'Act of nature',
+          ] as Initiator[],
+        },
+        slotDetail: {
+          duration: 57,
+          slotId: 1001,
+          start: '2018-12-10T08:10:00+00:00',
+        },
+        testCentre: {
+          centreId: 54321,
+          centreName: 'Example Test Centre',
+          costCode: 'EXTC1',
+        },
+        vehicleSlotType: 'B57mins',
+      },
+    ],
+  },
+  // Omit the first few bytes, as `echo -n '<stringified journal>' | gzip --no-name | base64` on OS X produces
+  // unix (0x03) as the OS header in the gzip output, whereas node sets it to 0x13 indicating OS X.
+  // tslint:disable-next-line:max-line-length
+  compressedJournalAsBase64: '11Ty27jIBT9FcR2XAmcuEm8c53MQ5qJRpMsRqq6IHCToGLwAE4TVf33udhulHZj4JzD5dyHX2mEEDfGxUDLx1e6c+5Z2wMtX6loW6OliNrZT8cfipY8n0yL+1n2fmMD/zqwEmg5yag8gnxe6oNOUXlGwUYdDTS41omi5V6YAEicI1gFaosmrmDr3cFDCPoElZS4uTKhBamFWQMoBGktrNJKRCBHEYi6BANnLWjW51QjfnD+grqKI3aCo5YGvoHwO3dOaBddg/lIJF/AhOONiTfM4T14Sv56qJTyvSMsyLD9qS1wDMfJJvbVwdUDRIx6o8hRsXENtEZgjT5Qk5GK7sUi07oQpVOQHD7wnEzqJb210xef8RtkLZre5F77EIcD/Wqc79uRUSOu6G9MPrj0St8PRH5pTAbDK4/V9uuu2YFPwlX1Z8N4keesWiy+13ijcTttYAsG2qOz6S6b3RdTMgxCMu51I/zlgyKRBMdkvmCoCCCdVZ8100nOCVvMMVpy0no4adcFbK4EY8b5e6SVjMTtiRWx80CfUBlwapcQhTYpe9X5UVvMBm6oVCpViMJja2nO+PyO53ecbdkcuZKxLyx908P90OCE+qHj/S6FKJLBbATGQq7OomkNkDQyZLyEEmxdPbRu9Xdb8xR1HLv0h20vbaIeilmjLVb96e0/Gxv6hn4DAAA=',
+};

--- a/src/functions/pollJournals/application/__tests__/journal-change-filter.spec.ts
+++ b/src/functions/pollJournals/application/__tests__/journal-change-filter.spec.ts
@@ -1,20 +1,20 @@
 import { Mock, Times } from 'typemoq';
 import * as journalRepository from '../../framework/repo/dynamodb/journal-repository';
 import { filterChangedJournals } from '../journal-change-filter';
-import { JournalWrapper } from '../../domain/journal-wrapper';
+import { JournalRecord } from '../../domain/journal-record';
 
 describe('JournalChangeFilter', () => {
   const moqGetStaffNumberHashMappings = Mock.ofInstance(journalRepository.getStaffNumbersWithHashes);
 
-  const dummyJournal1 = Mock.ofType<JournalWrapper>();
+  const dummyJournal1 = Mock.ofType<JournalRecord>();
   dummyJournal1.setup((x: any) => x.staffNumber).returns(() => '123');
   dummyJournal1.setup((x: any) => x.hash).returns(() => 'abc123');
 
-  const dummyJournal2 = Mock.ofType<JournalWrapper>();
+  const dummyJournal2 = Mock.ofType<JournalRecord>();
   dummyJournal2.setup((x: any) => x.staffNumber).returns(() => '456');
   dummyJournal2.setup((x: any) => x.hash).returns(() => 'abc456');
 
-  const dummyJournal3 = Mock.ofType<JournalWrapper>();
+  const dummyJournal3 = Mock.ofType<JournalRecord>();
   dummyJournal3.setup((x: any) => x.staffNumber).returns(() => '789');
   dummyJournal3.setup((x: any) => x.hash).returns(() => 'abc789');
 

--- a/src/functions/pollJournals/application/__tests__/journal-compressor.spec.ts
+++ b/src/functions/pollJournals/application/__tests__/journal-compressor.spec.ts
@@ -1,0 +1,15 @@
+import { compressJournal } from '../journal-compressor';
+import { ExaminerWorkSchedule } from '../../../../common/domain/Schema';
+import testJournalCompression from '../__mocks__/test-journal-compression';
+
+describe('JournalCompressor', () => {
+  describe('compressJournal', () => {
+    it('should gzip the journal JSON and return a base64 encoded version', () => {
+      const testJournal: ExaminerWorkSchedule = testJournalCompression.journal;
+
+      const compressedJournal = compressJournal(testJournal);
+
+      expect(compressedJournal.indexOf(testJournalCompression.compressedJournalAsBase64)).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/functions/pollJournals/application/journal-builder.ts
+++ b/src/functions/pollJournals/application/journal-builder.ts
@@ -8,6 +8,7 @@ import { ExaminerDeployment } from '../domain/examiner-deployment';
 import { ExaminerTestSlot } from '../domain/examiner-test-slot';
 import { ExaminerPersonalCommitment } from '../domain/examiner-personal-commitment';
 import { AllDatasets } from '../domain/all-datasets';
+import { compressJournal } from '../application/journal-compressor';
 
 export const buildJournals = (examiners: any[], datasets: AllDatasets): JournalRecord[] => {
   const testSlotsByExaminer = groupBy(datasets.testSlots, test => test.examinerId);
@@ -40,7 +41,8 @@ export const buildJournals = (examiners: any[], datasets: AllDatasets): JournalR
 
     const hash = crypto.createHash('sha256').update(JSON.stringify(journal)).digest('hex');
     const lastUpdatedAt = Date.now();
-    return { staffNumber, hash, lastUpdatedAt, journal };
+    const compressedJournal = compressJournal(journal);
+    return { staffNumber, hash, lastUpdatedAt, journal: compressedJournal };
   });
 
   return journals;

--- a/src/functions/pollJournals/application/journal-builder.ts
+++ b/src/functions/pollJournals/application/journal-builder.ts
@@ -1,6 +1,6 @@
 import { groupBy, get } from 'lodash';
 import { ExaminerWorkSchedule } from '../../../common/domain/Schema';
-import { JournalWrapper } from '../domain/journal-wrapper';
+import { JournalRecord } from '../domain/journal-record';
 import * as crypto from 'crypto';
 import { ExaminerNonTestActivity } from '../domain/examiner-non-test-activity';
 import { ExaminerAdvanceTestSlot } from '../domain/examiner-advance-test-slot';
@@ -9,7 +9,7 @@ import { ExaminerTestSlot } from '../domain/examiner-test-slot';
 import { ExaminerPersonalCommitment } from '../domain/examiner-personal-commitment';
 import { AllDatasets } from '../domain/all-datasets';
 
-export const buildJournals = (examiners: any[], datasets: AllDatasets): JournalWrapper[] => {
+export const buildJournals = (examiners: any[], datasets: AllDatasets): JournalRecord[] => {
   const testSlotsByExaminer = groupBy(datasets.testSlots, test => test.examinerId);
   const advanceTestsByExaminer = groupBy(datasets.advanceTestSlots, ats => ats.examinerId);
   const deploymentsByExaminer = groupBy(datasets.deployments, deployment => deployment.examinerId);
@@ -22,7 +22,7 @@ export const buildJournals = (examiners: any[], datasets: AllDatasets): JournalW
     personalCommitment => personalCommitment.examinerId,
   );
 
-  const journals: JournalWrapper[] = examiners.map((examiner) => {
+  const journals: JournalRecord[] = examiners.map((examiner) => {
     const individualId = examiner.individual_id.toString();
     const staffNumber = examiner.staff_number.toString();
     let journal: ExaminerWorkSchedule = {

--- a/src/functions/pollJournals/application/journal-change-filter.ts
+++ b/src/functions/pollJournals/application/journal-change-filter.ts
@@ -1,8 +1,8 @@
-import { JournalWrapper } from '../domain/journal-wrapper';
+import { JournalRecord } from '../domain/journal-record';
 import { getStaffNumbersWithHashes } from '../framework/repo/dynamodb/journal-repository';
 import { get } from 'lodash';
 
-export const filterChangedJournals = async (allJournals: JournalWrapper[]): Promise<JournalWrapper[]> => {
+export const filterChangedJournals = async (allJournals: JournalRecord[]): Promise<JournalRecord[]> => {
   const staffNumbersAndHashes = await getStaffNumbersWithHashes();
   const staffNumberHashMappings = createStaffNumberHashLookup(staffNumbersAndHashes);
 
@@ -15,7 +15,7 @@ export const filterChangedJournals = async (allJournals: JournalWrapper[]): Prom
   return filteredJournals;
 };
 
-const createStaffNumberHashLookup = (staffNumbersAndHashes: Partial<JournalWrapper>[]) => {
+const createStaffNumberHashLookup = (staffNumbersAndHashes: Partial<JournalRecord>[]) => {
   return staffNumbersAndHashes.reduce(
     (mappings, journalMeta) => {
       if (journalMeta.staffNumber && journalMeta.hash) {

--- a/src/functions/pollJournals/application/journal-compressor.ts
+++ b/src/functions/pollJournals/application/journal-compressor.ts
@@ -2,5 +2,5 @@ import { ExaminerWorkSchedule } from '../../../common/domain/Schema';
 import { gzipSync } from 'zlib';
 
 export const compressJournal = (journal: ExaminerWorkSchedule): string => {
-  return gzipSync(JSON.stringify(journal), { level: 6 }).toString('base64');
+  return gzipSync(JSON.stringify(journal)).toString('base64');
 };

--- a/src/functions/pollJournals/application/journal-compressor.ts
+++ b/src/functions/pollJournals/application/journal-compressor.ts
@@ -1,0 +1,5 @@
+import { ExaminerWorkSchedule } from '../../../common/domain/Schema';
+
+export const compressJournal = (journal: ExaminerWorkSchedule): string => {
+  return '';
+};

--- a/src/functions/pollJournals/application/journal-compressor.ts
+++ b/src/functions/pollJournals/application/journal-compressor.ts
@@ -1,5 +1,6 @@
 import { ExaminerWorkSchedule } from '../../../common/domain/Schema';
+import { gzipSync } from 'zlib';
 
 export const compressJournal = (journal: ExaminerWorkSchedule): string => {
-  return '';
+  return gzipSync(JSON.stringify(journal), { level: 6 }).toString('base64');
 };

--- a/src/functions/pollJournals/application/transfer-datasets.ts
+++ b/src/functions/pollJournals/application/transfer-datasets.ts
@@ -6,7 +6,7 @@ import { getDeployments } from '../framework/repo/mysql/deployment-repository';
 import { createConnectionPool } from '../framework/repo/mysql/pool';
 import { getExaminers } from '../framework/repo/mysql/examiner-repository';
 import { AllDatasets } from '../domain/all-datasets';
-import { JournalWrapper } from '../domain/journal-wrapper';
+import { JournalRecord } from '../domain/journal-record';
 import { buildJournals } from './journal-builder';
 import { chunk } from 'lodash';
 import { saveJournals } from '../framework/repo/dynamodb/journal-repository';
@@ -46,7 +46,7 @@ export const transferDatasets = async (): Promise<void> => {
   connectionPool.end();
 
   console.log(`FINISHED QUERY PHASE, STARTING TRANSFORM PHASE: ${new Date()}`);
-  const journals: JournalWrapper[] = buildJournals(examiners, datasets);
+  const journals: JournalRecord[] = buildJournals(examiners, datasets);
   console.log(`FINISHED TRANFORM PHASE, STARTING FILTER PHASE: ${new Date()}`);
 
   const changedJournals = await filterChangedJournals(journals);

--- a/src/functions/pollJournals/domain/journal-record.ts
+++ b/src/functions/pollJournals/domain/journal-record.ts
@@ -1,6 +1,6 @@
 import { ExaminerWorkSchedule } from '../../../common/domain/Schema';
 
-export interface JournalWrapper {
+export interface JournalRecord {
   staffNumber: string;
   hash: string;
   lastUpdatedAt: number;

--- a/src/functions/pollJournals/domain/journal-record.ts
+++ b/src/functions/pollJournals/domain/journal-record.ts
@@ -4,5 +4,5 @@ export interface JournalRecord {
   staffNumber: string;
   hash: string;
   lastUpdatedAt: number;
-  journal: ExaminerWorkSchedule;
+  journal: string;
 }


### PR DESCRIPTION
# Description and relevant Jira numbers
* Rename `JournalWrapper` to `JournalRecord`, replace `ExaminerWorkSchedule` with `string` for `journal` attribute.
* Introduce gzip compression + base64 encoding so we can save the compressed journal in DDB as a string.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [x] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA